### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -285,14 +285,15 @@ a {
 .item-img {
   width: 33vh;
   height: 33vh;
-  box-shadow: 7px 7px #696969;
+  box-shadow: 8px 8px #696969;
+  border-radius: 20px;
 }
 
 .item-img:active {
   box-shadow: none;
   position: relative;
-  top: 7px;
-  left: 7px
+  top: 8px;
+  left: 8px
 }
 
 

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -58,6 +58,25 @@
   color: #FFF;
   margin: 20px 0px;
   padding: 2vh 10vw;
+  border-radius: 15px;
+  box-shadow: 5px 5px #8b0000;
+  opacity: 0.8;
+}
+
+.item-red-btn:hover {
+  opacity: 1;
+  background-color:#ea352d;
+}
+
+.item-red-btn:active {
+  box-shadow: none;
+  position: relative;
+  top: 5px;
+  left: 5px
+}
+
+.item-red-btn:focus {
+	outline:0;
 }
 
 .or-text {
@@ -65,12 +84,27 @@
 }
 
 .item-destroy {
-  background-color: lightgray;
+  color: #fff;
+  background-color: #aaa;
   text-align: center;
-  font-size: 24px;
-  color: black;
   margin: 20px 0px;
   padding: 2vh 10vw;
+  border-radius: 15px;
+  font-size: 15px;
+  box-shadow: 5px 5px #696969;
+  opacity: 0.8;
+}
+
+.item-destroy:active {
+  box-shadow: none;
+  position: relative;
+  top: 5px;
+  left: 5px
+}
+
+.item-destroy:hover {
+  background-color: #aaa;
+  opacity: 1;
 }
 
 .item-explain-box {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,22 +18,22 @@ class ItemsController < ApplicationController
     end
   end
 
-  def destroy
-  end
+  # def destroy
+  # end
 
-  def update
-    item = Item.find(params[:id])
-    if item.update(item_params)
-      redirect_to root_path
-    else
-      render :edit
-    end
+  # def update
+  #   item = Item.find(params[:id])
+  #   if item.update(item_params)
+  #     redirect_to root_path
+  #   else
+  #     render :edit
+  #   end
 
-  end
+  # end
 
-  def edit
-    @item = Item.find(params[:id])
-  end
+  # def edit
+  #   @item = Item.find(params[:id])
+  # end
 
   def show
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,27 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+  end
+
+  def update
+    item = Item.find(params[:id])
+    if item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def checked
     item = Item.find(params[:id])
     if item.checked

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -27,6 +27,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /出品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -101,7 +102,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300", autocomplete: 'off' %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -138,10 +139,11 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
+
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,14 +123,14 @@
   <%# 商品一覧 %>
     <div class='item-contents'>
       <h2 class='title'>ピックアップカテゴリー</h2>
-      <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+      <%= link_to '新規投稿商品', root_path, class: "subtitle" %>
       <% if @items.present? %>
       <ul class='item-lists'>
 
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id), method: :get do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,7 +1,6 @@
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
@@ -112,8 +111,8 @@
           <span>販売利益</span>
           <span>
             <span id='profit'></span>円
+          </span>
         </div>
-        </span>
       </div>
     </div>
     <%# /販売価格 %>
@@ -141,7 +140,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path ,class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,33 +38,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.content %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,19 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@item.price}" %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,14 +24,15 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <% if current_user.present? %>
+    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,13 +24,13 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if current_user.present? %>
-    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if current_user.present?  %>
+      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :checked]
+  resources :items
   get 'items/:id', to: 'items#checked'
 end


### PR DESCRIPTION
ログイン中のユーザーもそうでないユーザーも、トップページの商品一覧に表示されている商品を選択することで、商品詳細のページへ飛ぶようにしました。

この時、出品者には編集と削除のリンクしか踏めなくなっており、出品者以外は商品の購入リンクが踏めるようになっています。

これにより、誤って出品者以外のユーザーが勝手に商品を編集できてしまう不具合を無くしました。

https://gyazo.com/926216a9da1482793be10a23adafaba6